### PR TITLE
FFIT-28-modulo-activo-inactivo-correctamente-dependiendos-sus-pagos

### DIFF
--- a/model/clienteDAO.php
+++ b/model/clienteDAO.php
@@ -136,8 +136,7 @@ class ClienteDAO extends Model implements CRUD
         require_once 'clienteDTO.php';
         $query = "SELECT c.*, pg.nombrePlanGym,
             (CASE
-            WHEN (SELECT MIN(ppgc.vencimiento) FROM pago_plan_gym_cliente ppgc WHERE ppgc.id_cliente = c.id_cliente) > CURDATE() THEN 1
-            ELSE 0
+            WHEN (SELECT MIN(ppgc.vencimiento) FROM pago_plan_gym_cliente ppgc WHERE ppgc.id_cliente = c.id_cliente AND ppgc.vencimiento > CURDATE()) IS NOT NULL THEN 1 ELSE 0
             END) as is_active
             FROM cliente AS c
             INNER JOIN usuario_gimnasio AS ug ON c.id_gimnasio = ug.id_gimnasio

--- a/model/planSistemaDAO.php
+++ b/model/planSistemaDAO.php
@@ -64,7 +64,7 @@
 
         public function readSystemPlan()
         {
-            require_once 'PlanSistemaDTO.php';
+            require_once 'planSistemaDTO.php';
             $query = "SELECT id_plan_sistema, nombre_plan_sistema
             FROM plan_sistema";
             $objPlanSistema = array();

--- a/model/usuarioDAO.php
+++ b/model/usuarioDAO.php
@@ -149,8 +149,7 @@ class UsuarioDAO extends Model implements CRUD
             ELSE ps.nombre_plan_sistema
         END AS nombrePlanSistema,
         CASE
-            WHEN (SELECT MIN(pps.vencimiento) FROM pago_plan_sistema pps WHERE pps.id_usuario = u.id_usuario) > CURDATE() THEN 1
-            ELSE 0
+        WHEN (SELECT MIN(pps.vencimiento) FROM pago_plan_sistema pps WHERE pps.id_usuario = u.id_usuario AND pps.vencimiento > CURDATE()) IS NOT NULL THEN 1 ELSE 0
         END AS is_active
     FROM usuario u
     LEFT JOIN usuario_gimnasio ug ON u.id_usuario = ug.id_usuario
@@ -187,9 +186,9 @@ class UsuarioDAO extends Model implements CRUD
     {
         require_once 'usuarioDTO.php';
         $query = $this->db->consultar("SELECT u.id_usuario, u.nombreUsuario, u.apellidoPaternoUsuario, u.apellidoMaternoUsuario, u.emailUsuario, u.passwordUsuario, u.imagen, u.calleUsuario, u.estadoUsuario, u.municipioUsuario, u.coloniaUsuario, u.codigoPostalUsuario, u.id_rol, ug.id_gimnasio,
-        (CASE WHEN u.id_rol = 2 THEN
-            (CASE WHEN (SELECT MIN(pps.vencimiento) FROM pago_plan_sistema pps WHERE pps.id_usuario = u.id_usuario) > CURDATE() THEN 1 ELSE 0 END)
-        ELSE 0 END) as is_active
+        (CASE WHEN u.id_rol = 2 AND EXISTS
+            (SELECT 1 FROM pago_plan_sistema pps WHERE pps.id_usuario = u.id_usuario AND pps.vencimiento > CURDATE()) THEN 1 ELSE 0
+        END) as is_active
         FROM usuario AS u
         LEFT JOIN usuario_gimnasio AS ug ON u.id_usuario = ug.id_usuario
         WHERE u.emailUsuario = '" . $data['emailUsuario'] . "' AND u.passwordUsuario ='" . $data['passwordUsuario'] . "'");

--- a/view/main/index.php
+++ b/view/main/index.php
@@ -65,7 +65,6 @@
                 data: datos,
                 dataType: "json",
                 success: function (data) {
-                    console.log(data);
                     if (data.error) {
                         Swal.fire(
                             "¡Error!",


### PR DESCRIPTION
FFIT-28 Se debe de mostrar correctamente el capo de activo o inactivo del cliente, usuario dependiendo sus pagos de cada uno y poder entrar  e iniciar sesion correctamente los gerentes cuando esten activos o inactivos.