### PR TITLE
FFIT-25 Nuevo botón para actualizar imágenes, solo si es necesario

### DIFF
--- a/controller/cliente.php
+++ b/controller/cliente.php
@@ -30,42 +30,34 @@ class Cliente extends Controller
 		$codigo_postal_cliente = $_POST['codigoPostalCliente'];
 		$numero_cliente = $_POST['numeroCliente'];
 		$email_cliente = $_POST['emailCliente'];
-		$nombreImagen = "";
-		if ($_FILES["imagen"]["name"] != null) {
-			$imagen = $_FILES["imagen"];
-			$nombreImagen = $imagen["name"];
-			$tipoImagen = $imagen["type"];
-			$ruta_provisional = $imagen["tmp_name"];
-			$fullname = $nombre_cliente . "_" . $apellido_paterno_cliente;
-			$carpeta = "public/cliente/" . $fullname . "/";
-			if ($tipoImagen != 'image/jpg' && $tipoImagen != 'image/jpeg' && $tipoImagen != 'image/png' && $tipoImagen != 'image/gif') {
-				echo 'errorimagen';
-			} else {
-				if (!file_exists($carpeta)) {
-					mkdir($carpeta, 0777, true);
-				}
-				copy($ruta_provisional, $carpeta . $nombreImagen);
+		$nombreImagen = $_FILES["imagen"]["name"];
 
-				$data = array(
-					'id_gimnasio' =>$id_gimnasio,
-					'id_PlanGym' =>$id_PlanGym,
-					'nombreCliente' => $nombre_cliente,
-					'apellidoPaternoCliente' => $apellido_paterno_cliente,
-					'apellidoMaternoCliente' => $apellido_materno_cliente,
-					'municipioCliente' => $municipio_cliente,
-					'coloniaCliente' => $colonia_cliente,
-					'calleCliente' => $calle_cliente,
-					'codigoPostalCliente' => $codigo_postal_cliente,
-					'numeroCliente' => $numero_cliente,
-					'emailCliente' => $email_cliente,
-					'imagen' => $nombreImagen,
-					'nombreImagen' => $nombreImagen
-				);
-				require 'model/clienteDAO.php';
-				$this->loadModel('ClienteDAO');
-				$clienteDAO = new ClienteDAO();
-				$clienteDAO->insert($data);
-			}
+		$data = array(
+			'id_gimnasio' => $id_gimnasio,
+			'id_PlanGym' => $id_PlanGym,
+			'nombreCliente' => $nombre_cliente,
+			'apellidoPaternoCliente' => $apellido_paterno_cliente,
+			'apellidoMaternoCliente' => $apellido_materno_cliente,
+			'municipioCliente' => $municipio_cliente,
+			'coloniaCliente' => $colonia_cliente,
+			'calleCliente' => $calle_cliente,
+			'codigoPostalCliente' => $codigo_postal_cliente,
+			'numeroCliente' => $numero_cliente,
+			'emailCliente' => $email_cliente,
+			'imagen' => $nombreImagen,
+			'nombreImagen' => $nombreImagen
+		);
+		if ($_FILES["imagen"]["name"] != null) {
+			require 'model/clienteDAO.php';
+			$this->loadModel('ClienteDAO');
+			$clienteDAO = new ClienteDAO();
+			$id_cliente = $clienteDAO->insert($data);
+			
+			require_once __DIR__ . '/services/saveImage.php';
+			$imagen = $_FILES["imagen"];
+			$Carpeta = "public/cliente/" . $id_cliente . "/";
+			SaveImage::invoke($Carpeta, $imagen);
+			echo "ok";
 		}
 	}
 
@@ -95,31 +87,6 @@ class Cliente extends Controller
 			'numero_cliente' => $numero_cliente,
 			'email_cliente' => $email_cliente,
 		);
-
-		if (isset($_FILES["imagenClienteActualizar"])) {
-
-			if ($_FILES["imagenClienteActualizar"]["name"] != null) {
-
-				$imagen = $_FILES["imagenClienteActualizar"];
-				$nombreImagen = $imagen["name"];
-				$tipoImagen = $imagen["type"];
-				$ruta_provisional = $imagen["tmp_name"];
-
-				$fullname = $nombre_cliente . "_" . $apellido_paterno_cliente;
-				$carpeta = "public/cliente/" . $fullname . "/";
-
-				if ($tipoImagen != 'image/jpg' && $tipoImagen != 'image/jpeg' && $tipoImagen != 'image/png' && $tipoImagen != 'image/gif') {
-					echo 'errorimagen';
-				} else {
-					if (!file_exists($carpeta)) {
-						mkdir($carpeta, 0777, true);
-					}
-					copy($ruta_provisional, $carpeta . $nombreImagen);
-					$arrayActualizar['imagen_cliente'] = $nombreImagen;
-				}
-			}
-		}
-
 		require 'model/clienteDAO.php';
 		$this->loadModel('ClienteDAO');
 		$clienteDAO = new ClienteDAO();
@@ -202,6 +169,23 @@ class Cliente extends Controller
 			$obj = array();
 		}
 		echo json_encode($obj);
+	}
+
+	function UpdateImage()
+	{
+		require_once __DIR__ . '/services/saveImage.php';
+		$id_cliente = $_POST['idClientUpdateImage'];
+		$imagen = $_FILES["imageInput"];
+		$Carpeta = "public/cliente/" . $id_cliente . "/";
+		$data = array(
+			'id_cliente' => $id_cliente,
+			'imageInput' => SaveImage::invoke($Carpeta, $imagen)
+		);
+
+		require 'model/clienteDAO.php';
+		$this->loadModel('ClienteDAO');
+		$clienteDAO = new ClienteDAO();
+		$clienteDAO = $clienteDAO->updateImage($data);
 	}
 }
 ?>

--- a/controller/cliente.php
+++ b/controller/cliente.php
@@ -19,31 +19,31 @@ class Cliente extends Controller
 
 	function insert()
 	{
-		$id_gimnasio = $_POST['id_gimnasio'];
-		$id_PlanGym = $_POST['id_PlanGym'];
-		$nombre_cliente = $_POST['nombreCliente'];
-		$apellido_paterno_cliente = $_POST['apellidoPaternoCliente'];
-		$apellido_materno_cliente = $_POST['apellidoMaternoCliente'];
-		$municipio_cliente = $_POST['municipioCliente'];
-		$colonia_cliente = $_POST['coloniaCliente'];
-		$calle_cliente = $_POST['calleCliente'];
-		$codigo_postal_cliente = $_POST['codigoPostalCliente'];
-		$numero_cliente = $_POST['numeroCliente'];
-		$email_cliente = $_POST['emailCliente'];
+		$idGimnasio = $_POST['id_gimnasio'];
+		$idPlanGym = $_POST['id_PlanGym'];
+		$nombreCliente = $_POST['nombreCliente'];
+		$apellidoPaternoCliente = $_POST['apellidoPaternoCliente'];
+		$apellidoMaternoCliente = $_POST['apellidoMaternoCliente'];
+		$municipioCliente = $_POST['municipioCliente'];
+		$coloniaCliente = $_POST['coloniaCliente'];
+		$calleCliente = $_POST['calleCliente'];
+		$codigoPostalCliente = $_POST['codigoPostalCliente'];
+		$numeroCliente = $_POST['numeroCliente'];
+		$emailCliente = $_POST['emailCliente'];
 		$nombreImagen = $_FILES["imagen"]["name"];
 
 		$data = array(
-			'id_gimnasio' => $id_gimnasio,
-			'id_PlanGym' => $id_PlanGym,
-			'nombreCliente' => $nombre_cliente,
-			'apellidoPaternoCliente' => $apellido_paterno_cliente,
-			'apellidoMaternoCliente' => $apellido_materno_cliente,
-			'municipioCliente' => $municipio_cliente,
-			'coloniaCliente' => $colonia_cliente,
-			'calleCliente' => $calle_cliente,
-			'codigoPostalCliente' => $codigo_postal_cliente,
-			'numeroCliente' => $numero_cliente,
-			'emailCliente' => $email_cliente,
+			'id_gimnasio' => $idGimnasio,
+			'id_PlanGym' => $idPlanGym,
+			'nombreCliente' => $nombreCliente,
+			'apellidoPaternoCliente' => $apellidoPaternoCliente,
+			'apellidoMaternoCliente' => $apellidoMaternoCliente,
+			'municipioCliente' => $municipioCliente,
+			'coloniaCliente' => $coloniaCliente,
+			'calleCliente' => $calleCliente,
+			'codigoPostalCliente' => $codigoPostalCliente,
+			'numeroCliente' => $numeroCliente,
+			'emailCliente' => $emailCliente,
 			'imagen' => $nombreImagen,
 			'nombreImagen' => $nombreImagen
 		);
@@ -51,41 +51,40 @@ class Cliente extends Controller
 			require 'model/clienteDAO.php';
 			$this->loadModel('ClienteDAO');
 			$clienteDAO = new ClienteDAO();
-			$id_cliente = $clienteDAO->insert($data);
+			$idCliente = $clienteDAO->insert($data);
 			
 			require_once __DIR__ . '/services/saveImage.php';
 			$imagen = $_FILES["imagen"];
-			$Carpeta = "public/cliente/" . $id_cliente . "/";
-			SaveImage::invoke($Carpeta, $imagen);
+			$carpeta = "public/cliente/" . $idCliente . "/";
+			SaveImage::invoke($carpeta, $imagen);
 			echo "ok";
 		}
 	}
 
 	function update()
 	{
-		$id_cliente = $_POST['id_clienteActualizar'];
-		$nombre_cliente = $_POST['nombreClienteActualizar'];
-		$apellido_paterno_cliente = $_POST['apellidoPaternoClienteActualizar'];
-		$apellido_materno_cliente = $_POST['apellidoMaternoClienteActualizar'];
-		$municipio_cliente = $_POST['municipioClienteActualizar'];
-		$colonia_cliente = $_POST['coloniaClienteActualizar'];
-		$calle_cliente = $_POST['calleClienteActualizar'];
-		$codigo_postal_cliente = $_POST['codigoPostalClienteActualizar'];
-		$numero_cliente = $_POST['numeroClienteActualizar'];
-		$email_cliente = $_POST['emailClienteActualizar'];
-		$nombreImagen = "";
+		$idCliente = $_POST['id_clienteActualizar'];
+		$nombreCliente = $_POST['nombreClienteActualizar'];
+		$apellidoPaternoCliente = $_POST['apellidoPaternoClienteActualizar'];
+		$apellidoMaternoCliente = $_POST['apellidoMaternoClienteActualizar'];
+		$municipioCliente = $_POST['municipioClienteActualizar'];
+		$coloniaCliente = $_POST['coloniaClienteActualizar'];
+		$calleCliente = $_POST['calleClienteActualizar'];
+		$codigoPostalCliente = $_POST['codigoPostalClienteActualizar'];
+		$numeroCliente = $_POST['numeroClienteActualizar'];
+		$emailCliente = $_POST['emailClienteActualizar'];
 
 		$arrayActualizar = array(
-			'id_cliente' => $id_cliente,
-			'nombre_cliente' => $nombre_cliente,
-			'apellido_paterno_cliente' => $apellido_paterno_cliente,
-			'apellido_materno_cliente' => $apellido_materno_cliente,
-			'municipio_cliente' => $municipio_cliente,
-			'colonia_cliente' => $colonia_cliente,
-			'calle_cliente' => $calle_cliente,
-			'codigo_postal_cliente' => $codigo_postal_cliente,
-			'numero_cliente' => $numero_cliente,
-			'email_cliente' => $email_cliente,
+			'id_cliente' => $idCliente,
+			'nombre_cliente' => $nombreCliente,
+			'apellido_paterno_cliente' => $apellidoPaternoCliente,
+			'apellido_materno_cliente' => $apellidoMaternoCliente,
+			'municipio_cliente' => $municipioCliente,
+			'colonia_cliente' => $coloniaCliente,
+			'calle_cliente' => $calleCliente,
+			'codigo_postal_cliente' => $codigoPostalCliente,
+			'numero_cliente' => $numeroCliente,
+			'email_cliente' => $emailCliente,
 		);
 		require 'model/clienteDAO.php';
 		$this->loadModel('ClienteDAO');
@@ -171,15 +170,15 @@ class Cliente extends Controller
 		echo json_encode($obj);
 	}
 
-	function UpdateImage()
+	function updateImage()
 	{
 		require_once __DIR__ . '/services/saveImage.php';
-		$id_cliente = $_POST['idClientUpdateImage'];
+		$idCliente = $_POST['idClientUpdateImage'];
 		$imagen = $_FILES["imageInput"];
-		$Carpeta = "public/cliente/" . $id_cliente . "/";
+		$carpeta = "public/cliente/" . $idCliente . "/";
 		$data = array(
-			'id_cliente' => $id_cliente,
-			'imageInput' => SaveImage::invoke($Carpeta, $imagen)
+			'id_cliente' => $idCliente,
+			'imageInput' => SaveImage::invoke($carpeta, $imagen)
 		);
 
 		require 'model/clienteDAO.php';

--- a/controller/gimnasio.php
+++ b/controller/gimnasio.php
@@ -19,12 +19,12 @@ class Gimnasio extends Controller
 
     function insert()
     {
-        $nombre_gimnasio = $_POST['nombreGimnasio'];
+        $nombreGimnasio = $_POST['nombreGimnasio'];
         $telefono = $_POST['telefono'];
         $nombreImagen = $_FILES["imagen"]["name"];
 
         $data = array(
-            'nombre_gimnasio' => $nombre_gimnasio,
+            'nombre_gimnasio' => $nombreGimnasio,
             'telefono' => $telefono,
             'imagen' => $nombreImagen,
             'nombreImagen' => $nombreImagen
@@ -34,25 +34,25 @@ class Gimnasio extends Controller
             require 'model/gimnasioDAO.php';
             $this->loadModel('GimnasioDAO');
             $gimnasioDAO = new GimnasioDAO();
-            $id_gimnasio = $gimnasioDAO->insert($data);
+            $idGimnasio = $gimnasioDAO->insert($data);
 
             require_once __DIR__ . '/services/saveImage.php';
             $imagen = $_FILES["imagen"];
-            $Carpeta = "public/gimnasio/" . $id_gimnasio . "/";
-            SaveImage::invoke($Carpeta, $imagen);
+            $carpeta = "public/gimnasio/" . $idGimnasio . "/";
+            SaveImage::invoke($carpeta, $imagen);
             echo "ok";
         }
     }
 
     function update()
     {
-        $id_gimnasio = $_POST['idGimnasioActualizar'];
-        $nombre_gimnasio = $_POST['nombreGimnasioActualizar'];
+        $idGimnasio = $_POST['idGimnasioActualizar'];
+        $nombreGimnasio = $_POST['nombreGimnasioActualizar'];
         $telefono = $_POST['telefonoActualizar'];
 
         $arrayActualizar = array(
-            'id_gimnasio' => $id_gimnasio,
-            'nombre_gimnasio' => $nombre_gimnasio,
+            'id_gimnasio' => $idGimnasio,
+            'nombre_gimnasio' => $nombreGimnasio,
             'telefono' => $telefono,
         );
 
@@ -98,15 +98,15 @@ class Gimnasio extends Controller
         echo json_encode($obj);
     }
 
-    function UpdateImage()
+    function updateImage()
 	{
 		require_once __DIR__ . '/services/saveImage.php';
-		$id_gimnasio = $_POST['idGymUpdateImage'];
+		$idGimnasio = $_POST['idGymUpdateImage'];
 		$imagen = $_FILES["imageInput"];
-		$Carpeta = "public/gimnasio/" . $id_gimnasio . "/";
+		$carpeta = "public/gimnasio/" . $idGimnasio . "/";
 		$data = array(
-			'id_gimnasio' => $id_gimnasio,
-			'imageInput' => SaveImage::invoke($Carpeta, $imagen)
+			'id_gimnasio' => $idGimnasio,
+			'imageInput' => SaveImage::invoke($carpeta, $imagen)
 		);
 
 		require 'model/gimnasioDAO.php';

--- a/controller/gimnasio.php
+++ b/controller/gimnasio.php
@@ -21,33 +21,26 @@ class Gimnasio extends Controller
     {
         $nombre_gimnasio = $_POST['nombreGimnasio'];
         $telefono = $_POST['telefono'];
-        $nombreImagen = "";
-        if ($_FILES["imagen"]["name"] != null) {
-            $imagen = $_FILES["imagen"];
-            $nombreImagen = $imagen["name"];
-            $tipoImagen = $imagen["type"];
-            $ruta_provisional = $imagen["tmp_name"];
-            $fullname = $nombre_gimnasio . "_" . $telefono;
-            $carpeta = "public/gimnasio/" . $fullname . "/";
-            if ($tipoImagen != 'image/jpg' && $tipoImagen != 'image/jpeg' && $tipoImagen != 'image/png' && $tipoImagen != 'image/gif') {
-                echo 'errorimagen';
-            } else {
-                if (!file_exists($carpeta)) {
-                    mkdir($carpeta, 0777, true);
-                }
-                copy($ruta_provisional, $carpeta . $nombreImagen);
+        $nombreImagen = $_FILES["imagen"]["name"];
 
-                $data = array(
-                    'nombre_gimnasio' => $nombre_gimnasio,
-                    'telefono' => $telefono,
-                    'imagen' => $nombreImagen,
-                    'nombreImagen' => $nombreImagen
-                );
-                require 'model/gimnasioDAO.php';
-                $this->loadModel('GimnasioDAO');
-                $gimnasioDAO = new GimnasioDAO();
-                $gimnasioDAO->insert($data);
-            }
+        $data = array(
+            'nombre_gimnasio' => $nombre_gimnasio,
+            'telefono' => $telefono,
+            'imagen' => $nombreImagen,
+            'nombreImagen' => $nombreImagen
+        );
+
+        if ($_FILES["imagen"]["name"] != null) {
+            require 'model/gimnasioDAO.php';
+            $this->loadModel('GimnasioDAO');
+            $gimnasioDAO = new GimnasioDAO();
+            $id_gimnasio = $gimnasioDAO->insert($data);
+
+            require_once __DIR__ . '/services/saveImage.php';
+            $imagen = $_FILES["imagen"];
+            $Carpeta = "public/gimnasio/" . $id_gimnasio . "/";
+            SaveImage::invoke($Carpeta, $imagen);
+            echo "ok";
         }
     }
 
@@ -56,37 +49,12 @@ class Gimnasio extends Controller
         $id_gimnasio = $_POST['idGimnasioActualizar'];
         $nombre_gimnasio = $_POST['nombreGimnasioActualizar'];
         $telefono = $_POST['telefonoActualizar'];
-        $nombreImagen = "";
 
         $arrayActualizar = array(
             'id_gimnasio' => $id_gimnasio,
             'nombre_gimnasio' => $nombre_gimnasio,
             'telefono' => $telefono,
         );
-
-        if (isset($_FILES["imagenGimnasioActualizar"])) {
-
-            if ($_FILES["imagenGimnasioActualizar"]["name"] != null) {
-
-                $imagen = $_FILES["imagenGimnasioActualizar"];
-                $nombreImagen = $imagen["name"];
-                $tipoImagen = $imagen["type"];
-                $ruta_provisional = $imagen["tmp_name"];
-
-                $fullname = $nombre_gimnasio . "_" . $telefono;
-                $carpeta = "public/gimnasio/" . $fullname . "/";
-
-                if ($tipoImagen != 'image/jpg' && $tipoImagen != 'image/jpeg' && $tipoImagen != 'image/png' && $tipoImagen != 'image/gif') {
-                    echo 'errorimagen';
-                } else {
-                    if (!file_exists($carpeta)) {
-                        mkdir($carpeta, 0777, true);
-                    }
-                    copy($ruta_provisional, $carpeta . $nombreImagen);
-                    $arrayActualizar['imagen'] = $nombreImagen;
-                }
-            }
-        }
 
         require 'model/gimnasioDAO.php';
         $this->loadModel('GimnasioDAO');
@@ -129,4 +97,21 @@ class Gimnasio extends Controller
         }
         echo json_encode($obj);
     }
+
+    function UpdateImage()
+	{
+		require_once __DIR__ . '/services/saveImage.php';
+		$id_gimnasio = $_POST['idGymUpdateImage'];
+		$imagen = $_FILES["imageInput"];
+		$Carpeta = "public/gimnasio/" . $id_gimnasio . "/";
+		$data = array(
+			'id_gimnasio' => $id_gimnasio,
+			'imageInput' => SaveImage::invoke($Carpeta, $imagen)
+		);
+
+		require 'model/gimnasioDAO.php';
+		$this->loadModel('GimnasioDAO');
+		$gimnasioDAO = new GimnasioDAO();
+		$gimnasioDAO = $gimnasioDAO->updateImage($data);
+	}
 }

--- a/controller/perfil.php
+++ b/controller/perfil.php
@@ -31,12 +31,10 @@ class Perfil extends Controller
         $municipalityUser = $_POST['municipalityUser'];
         $colonyUser = $_POST['colonyUser'];
         $postalcodeUser = $_POST['postalcodeUser'];
-        $id_usuario = $_POST['id_usuario'];
-        $oldNameUser = $_POST['oldNameUser'];
-        $oldLastNameUser = $_POST['oldLastNameUser'];
+        $idUsuario = $_POST['idUsuario'];
 
         $data = array(
-            'id_usuario' => $id_usuario,
+            'id_usuario' => $idUsuario,
             'nameUser' => $nameUser,
             'lastNameP' => $lastNameP,
             'lastNameM' => $lastNameM,
@@ -47,29 +45,12 @@ class Perfil extends Controller
             'colonyUser' => $colonyUser,
             'postalcodeUser' => $postalcodeUser
         );
-
-        $newFullname = $nameUser . "_" . $lastNameP;
-        $newCarpeta = "public/usuario/" . $id_usuario . "_" . $newFullname . "/";
-        if (!file_exists($newCarpeta)) {
-            mkdir($newCarpeta, 0777, true);
-        }
-
-        if ($oldNameUser != $nameUser || $lastNameP != $oldLastNameUser) {
-            $oldFullname = $oldNameUser . "_" . $oldLastNameUser;
-            $oldCarpeta = "public/usuario/" . $id_usuario . "_" . $oldFullname . "/" . $_POST['imagen'];
-
-            copy($oldCarpeta, $newCarpeta . $_POST['imagen']);
-        }
-
+        
         if (!empty($_FILES["imageUserUpdate"]["name"])) {
+            require_once __DIR__ . '/services/saveImage.php';
             $imagen = $_FILES["imageUserUpdate"];
-            $nombreImagen = $imagen["name"];
-            $tipoImagen = $imagen["type"];
-            $ruta_provisional = $imagen["tmp_name"];
-            if ($tipoImagen === 'image/jpg' || $tipoImagen === 'image/jpeg' || $tipoImagen === 'image/png' || $tipoImagen === 'image/gif') {
-                copy($ruta_provisional, $newCarpeta . $nombreImagen);
-                $data['imageUserUpdate'] = $nombreImagen;
-            }
+            $carpeta = "public/usuario/" . $idUsuario . "/";
+            $data['imageUserUpdate'] = SaveImage::invoke($carpeta, $imagen);
         }
 
         require 'model/perfilDAO.php';

--- a/controller/services/saveImage.php
+++ b/controller/services/saveImage.php
@@ -1,0 +1,16 @@
+<?php
+class SaveImage
+{
+    public static function invoke($Carpeta, $imagen)
+    {
+        if (!file_exists($Carpeta)) {
+            mkdir($Carpeta, 0777, true);
+        }
+        
+        $nombreImagen = $imagen["name"];
+        $ruta_provisional = $imagen["tmp_name"];
+        
+        copy($ruta_provisional, $Carpeta . $nombreImagen);
+        return $nombreImagen;
+    }
+}

--- a/controller/services/saveImage.php
+++ b/controller/services/saveImage.php
@@ -1,16 +1,16 @@
 <?php
 class SaveImage
 {
-    public static function invoke($Carpeta, $imagen)
+    public static function invoke($carpeta, $imagen)
     {
-        if (!file_exists($Carpeta)) {
-            mkdir($Carpeta, 0777, true);
+        if (!file_exists($carpeta)) {
+            mkdir($carpeta, 0777, true);
         }
         
         $nombreImagen = $imagen["name"];
-        $ruta_provisional = $imagen["tmp_name"];
+        $rutaProvisional = $imagen["tmp_name"];
         
-        copy($ruta_provisional, $Carpeta . $nombreImagen);
+        copy($rutaProvisional, $carpeta . $nombreImagen);
         return $nombreImagen;
     }
 }

--- a/controller/usuario.php
+++ b/controller/usuario.php
@@ -29,7 +29,7 @@ class Usuario extends Controller
 		$municipioUsuario = $_POST['municipioUsuario'];
 		$coloniaUsuario = $_POST['coloniaUsuario'];
 		$codigoPostalUsuario = $_POST['codigoPostalUsuario'];
-		$id_rol = $_POST['rolUsuario'];
+		$idRol = $_POST['rolUsuario'];
 		$nombreImagen = $_FILES["imagen"]["name"];
 
 		$data = array(
@@ -43,7 +43,7 @@ class Usuario extends Controller
 			'municipioUsuario' => $municipioUsuario,
 			'coloniaUsuario' => $coloniaUsuario,
 			'codigoPostalUsuario' => $codigoPostalUsuario,
-			'rolUsuario' => $id_rol,
+			'rolUsuario' => $idRol,
 			'imagen' => $nombreImagen,
 			'nombreImagen' => $nombreImagen
 		);
@@ -52,19 +52,19 @@ class Usuario extends Controller
 			require 'model/usuarioDAO.php';
 			$this->loadModel('UsuarioDAO');
 			$usuarioDAO = new UsuarioDAO();
-			$id_usuario = $usuarioDAO->insert($data);
+			$idUsuario = $usuarioDAO->insert($data);
 	
 			require_once __DIR__ . '/services/saveImage.php';
 			$imagen = $_FILES["imagen"];
-			$Carpeta = "public/usuario/" . $id_usuario . "/";
-			SaveImage::invoke($Carpeta, $imagen);
+			$carpeta = "public/usuario/" . $idUsuario . "/";
+			SaveImage::invoke($carpeta, $imagen);
 			echo "ok";
 		}
 	}
 
 	function update()
 	{
-		$id_usuario = $_POST['id_usuarioActualizar'];
+		$idUsuario = $_POST['id_usuarioActualizar'];
 		$nombreUsuario = $_POST['nombreUsuarioActualizar'];
 		$apellidoPaternoUsuario = $_POST['apellidoPaternoUsuarioActualizar'];
 		$apellidoMaternoUsuario = $_POST['apellidoMaternoUsuarioActualizar'];
@@ -75,10 +75,10 @@ class Usuario extends Controller
 		$municipioUsuario = $_POST['municipioUsuarioActualizar'];
 		$coloniaUsuario = $_POST['coloniaUsuarioActualizar'];
 		$codigoPostalUsuario = $_POST['codigopostalUsuarioActualizar'];
-		$id_rol = $_POST['rolUsuarioActualizar'];
+		$idRol = $_POST['rolUsuarioActualizar'];
 
 		$arrayActualizar = array(
-			'id_usuario' => $id_usuario,
+			'id_usuario' => $idUsuario,
 			'nombreUsuario' => $nombreUsuario,
 			'apellidoPaternoUsuario' => $apellidoPaternoUsuario,
 			'apellidoMaternoUsuario' => $apellidoMaternoUsuario,
@@ -89,7 +89,7 @@ class Usuario extends Controller
 			'municipioUsuario' => $municipioUsuario,
 			'coloniaUsuario' => $coloniaUsuario,
 			'codigoPostalUsuario' => $codigoPostalUsuario,
-			'id_rol' => $id_rol,
+			'id_rol' => $idRol,
 		);
 
 		require 'model/usuarioDAO.php';
@@ -163,15 +163,15 @@ class Usuario extends Controller
 				$usuarioDAO->insertGymAndPlanSistema($data);
 	}
 
-	function UpdateImage()
+	function updateImage()
 	{
 		require_once __DIR__ . '/services/saveImage.php';
-		$id_user = $_POST['idUserUpdateImage'];
+		$idUser = $_POST['idUserUpdateImage'];
 		$imagen = $_FILES["imageInput"];
-		$Carpeta = "public/usuario/" . $id_user . "/";
+		$carpeta = "public/usuario/" . $idUser . "/";
 		$data = array(
-			'id_user' => $id_user,
-			'imageInput' => SaveImage::invoke($Carpeta, $imagen)
+			'id_user' => $idUser,
+			'imageInput' => SaveImage::invoke($carpeta, $imagen)
 		);
 
 		require 'model/usuarioDAO.php';

--- a/controller/usuario.php
+++ b/controller/usuario.php
@@ -30,42 +30,35 @@ class Usuario extends Controller
 		$coloniaUsuario = $_POST['coloniaUsuario'];
 		$codigoPostalUsuario = $_POST['codigoPostalUsuario'];
 		$id_rol = $_POST['rolUsuario'];
-		$nombreImagen = "";
-		if ($_FILES["imagen"]["name"] != null) {
-			$imagen = $_FILES["imagen"];
-			$nombreImagen = $imagen["name"];
-			$tipoImagen = $imagen["type"];
-			$ruta_provisional = $imagen["tmp_name"];
-			$fullname = $nombreUsuario . "_" . $apellidoPaternoUsuario;
-			$carpeta = "public/usuario/" . $fullname . "/";
-			if ($tipoImagen != 'image/jpg' && $tipoImagen != 'image/jpeg' && $tipoImagen != 'image/png' && $tipoImagen != 'image/gif') {
-				echo 'errorimagen';
-			} else {
-				if (!file_exists($carpeta)) {
-					mkdir($carpeta, 0777, true);
-				}
-				copy($ruta_provisional, $carpeta . $nombreImagen);
+		$nombreImagen = $_FILES["imagen"]["name"];
 
-				$data = array(
-					'nombreUsuario' => $nombreUsuario,
-					'apellidoPaternoUsuario' => $apellidoPaternoUsuario,
-					'apellidoMaternoUsuario' => $apellidoMaternoUsuario,
-					'correoUsuario' => $emailUsuario,
-					'password' => $passwordUsuario,
-					'calleUsuario' => $calleUsuario,
-					'estadoUsuario' => $estadoUsuario,
-					'municipioUsuario' => $municipioUsuario,
-					'coloniaUsuario' => $coloniaUsuario,
-					'codigoPostalUsuario' => $codigoPostalUsuario,
-					'rolUsuario' => $id_rol,
-					'imagen' => $nombreImagen,
-					'nombreImagen' => $nombreImagen
-				);
-				require 'model/usuarioDAO.php';
-				$this->loadModel('UsuarioDAO');
-				$usuarioDAO = new UsuarioDAO();
-				$usuarioDAO->insert($data);
-			}
+		$data = array(
+			'nombreUsuario' => $nombreUsuario,
+			'apellidoPaternoUsuario' => $apellidoPaternoUsuario,
+			'apellidoMaternoUsuario' => $apellidoMaternoUsuario,
+			'correoUsuario' => $emailUsuario,
+			'password' => $passwordUsuario,
+			'calleUsuario' => $calleUsuario,
+			'estadoUsuario' => $estadoUsuario,
+			'municipioUsuario' => $municipioUsuario,
+			'coloniaUsuario' => $coloniaUsuario,
+			'codigoPostalUsuario' => $codigoPostalUsuario,
+			'rolUsuario' => $id_rol,
+			'imagen' => $nombreImagen,
+			'nombreImagen' => $nombreImagen
+		);
+
+		if ($_FILES["imagen"]["name"] != null) {
+			require 'model/usuarioDAO.php';
+			$this->loadModel('UsuarioDAO');
+			$usuarioDAO = new UsuarioDAO();
+			$id_usuario = $usuarioDAO->insert($data);
+	
+			require_once __DIR__ . '/services/saveImage.php';
+			$imagen = $_FILES["imagen"];
+			$Carpeta = "public/usuario/" . $id_usuario . "/";
+			SaveImage::invoke($Carpeta, $imagen);
+			echo "ok";
 		}
 	}
 
@@ -83,7 +76,6 @@ class Usuario extends Controller
 		$coloniaUsuario = $_POST['coloniaUsuarioActualizar'];
 		$codigoPostalUsuario = $_POST['codigopostalUsuarioActualizar'];
 		$id_rol = $_POST['rolUsuarioActualizar'];
-		$nombreImagen = "";
 
 		$arrayActualizar = array(
 			'id_usuario' => $id_usuario,
@@ -99,28 +91,6 @@ class Usuario extends Controller
 			'codigoPostalUsuario' => $codigoPostalUsuario,
 			'id_rol' => $id_rol,
 		);
-
-		if (isset($_FILES["imagenUsuarioActualizar"])) {
-			if ($_FILES["imagenUsuarioActualizar"]["name"] != null) {
-				$imagen = $_FILES["imagenUsuarioActualizar"];
-				$nombreImagen = $imagen["name"];
-				$tipoImagen = $imagen["type"];
-				$ruta_provisional = $imagen["tmp_name"];
-
-				$fullname = $nombreUsuario . "_" . $apellidoPaternoUsuario;
-				$carpeta = "public/usuario/" . $fullname . "/";
-
-				if ($tipoImagen != 'image/jpg' && $tipoImagen != 'image/jpeg' && $tipoImagen != 'image/png' && $tipoImagen != 'image/gif') {
-					echo 'errorimagen';
-				} else {
-					if (!file_exists($carpeta)) {
-						mkdir($carpeta, 0777, true);
-					}
-					copy($ruta_provisional, $carpeta . $nombreImagen);
-					$arrayActualizar['imagen'] = $nombreImagen;
-				}
-			}
-		}
 
 		require 'model/usuarioDAO.php';
 		$this->loadModel('UsuarioDAO');
@@ -191,6 +161,23 @@ class Usuario extends Controller
 				$this->loadModel('UsuarioDAO');
 				$usuarioDAO = new UsuarioDAO();
 				$usuarioDAO->insertGymAndPlanSistema($data);
+	}
+
+	function UpdateImage()
+	{
+		require_once __DIR__ . '/services/saveImage.php';
+		$id_user = $_POST['idUserUpdateImage'];
+		$imagen = $_FILES["imageInput"];
+		$Carpeta = "public/usuario/" . $id_user . "/";
+		$data = array(
+			'id_user' => $id_user,
+			'imageInput' => SaveImage::invoke($Carpeta, $imagen)
+		);
+
+		require 'model/usuarioDAO.php';
+		$this->loadModel('UsuarioDAO');
+		$usuarioDAO = new UsuarioDAO();
+		$usuarioDAO = $usuarioDAO->updateImage($data);
 	}
 }
 ?>

--- a/libs/conexion.php
+++ b/libs/conexion.php
@@ -48,6 +48,10 @@
             }
         }
 
+        /*Método para obtener el id del ultimo registro*/
+        public function getLastInsertId() {
+            return $this->conexion->lastInsertId();
+        }
 
         //Método que ejecuta un insert, update y delete, según lo requiera.
         public function ejecutarAccion($accion, $valores = array()) {

--- a/model/clienteDAO.php
+++ b/model/clienteDAO.php
@@ -11,7 +11,23 @@ class ClienteDAO extends Model implements CRUD
 
     public function insert($data)
     {
-        $query = $this->db->conectar()->prepare('INSERT INTO cliente values (NULL, 
+        $insertData = array(
+            ':id_gimnasio'=> $data['id_gimnasio'],
+            ':id_planGym' =>$data['id_PlanGym'],
+            ':nombre_cliente' => $data['nombreCliente'],
+            ':apellido_paterno_cliente' => $data['apellidoPaternoCliente'],
+            ':apellido_materno_cliente' => $data['apellidoMaternoCliente'],
+            ':municipio_cliente' => $data['municipioCliente'],
+            ':colonia_cliente' => $data['coloniaCliente'],
+            ':calle_cliente' => $data['calleCliente'],
+            ':codigo_postal_cliente' => $data['codigoPostalCliente'],
+            ':numero_cliente' => $data['numeroCliente'],
+            ':imagen_cliente' => $data['imagen'],
+            ':email_cliente' => $data['emailCliente'],
+            ':is_email_notified' => self::NOTIFICATION_NOT_SENT,
+            ':is_active' => self::CUSTOMER_INACTIVE
+        );
+        $query ="INSERT INTO cliente values (NULL,
                 :id_gimnasio,
                 :id_planGym,
                 :nombre_cliente, 
@@ -25,66 +41,27 @@ class ClienteDAO extends Model implements CRUD
                 :imagen_cliente,
                 :email_cliente,
                 :is_email_notified,
-                :is_active)');
-        $query->execute([
-            'id_gimnasio'=> $data['id_gimnasio'],
-            'id_planGym' =>$data['id_PlanGym'],
-            ':nombre_cliente' => $data['nombreCliente'],
-            ':apellido_paterno_cliente' => $data['apellidoPaternoCliente'],
-            ':apellido_materno_cliente' => $data['apellidoMaternoCliente'],
-            ':municipio_cliente' => $data['municipioCliente'],
-            ':colonia_cliente' => $data['coloniaCliente'],
-            ':calle_cliente' => $data['calleCliente'],
-            ':codigo_postal_cliente' => $data['codigoPostalCliente'],
-            ':numero_cliente' => $data['numeroCliente'],
-            ':imagen_cliente' => $data['imagen'],
-            ':email_cliente' => $data['emailCliente'],
-            ':is_email_notified' => self::NOTIFICATION_NOT_SENT,
-            ':is_active' => self::CUSTOMER_INACTIVE,
-        ]);
-        echo 'ok';
+                :is_active)";
+        if ($this->db->ejecutarAccion($query, $insertData)) {
+            return $this->db->getLastInsertId();
+        }
     }
 
     public function update($data)
     {
-        $imagen_cliente = '';
-
-        $arrayActualizar = [];
-
-        if (isset($data['imagen_cliente'])) {
-
-            $imagen_cliente = 'imagen_cliente = :imagen_cliente,';
-
-            $arrayActualizar = [
-                ':id_cliente' => $data['id_cliente'],
-                ':nombre_cliente' => $data['nombre_cliente'],
-                ':apellido_paterno_cliente' => $data['apellido_paterno_cliente'],
-                ':apellido_materno_cliente' => $data['apellido_materno_cliente'],
-                ':municipio_cliente' => $data['municipio_cliente'],
-                ':colonia_cliente' => $data['colonia_cliente'],
-                ':calle_cliente' => $data['calle_cliente'],
-                ':codigo_postal_cliente' => $data['codigo_postal_cliente'],
-                ':numero_cliente' => $data['numero_cliente'],
-                ':email_cliente' => $data['email_cliente'],
-                ':imagen_cliente' => $data['imagen_cliente']
-            ];
-        } else {
-            $arrayActualizar = [
-                ':id_cliente' => $data['id_cliente'],
-                ':nombre_cliente' => $data['nombre_cliente'],
-                ':apellido_paterno_cliente' => $data['apellido_paterno_cliente'],
-                ':apellido_materno_cliente' => $data['apellido_materno_cliente'],
-                ':municipio_cliente' => $data['municipio_cliente'],
-                ':colonia_cliente' => $data['colonia_cliente'],
-                ':calle_cliente' => $data['calle_cliente'],
-                ':codigo_postal_cliente' => $data['codigo_postal_cliente'],
-                ':numero_cliente' => $data['numero_cliente'],
-                ':email_cliente' => $data['email_cliente'],
-                ':imagen_cliente' => $data['imagen_cliente']
-            ];
-        }
+        $arrayActualizar = [
+            ':id_cliente' => $data['id_cliente'],
+            ':nombre_cliente' => $data['nombre_cliente'],
+            ':apellido_paterno_cliente' => $data['apellido_paterno_cliente'],
+            ':apellido_materno_cliente' => $data['apellido_materno_cliente'],
+            ':municipio_cliente' => $data['municipio_cliente'],
+            ':colonia_cliente' => $data['colonia_cliente'],
+            ':calle_cliente' => $data['calle_cliente'],
+            ':codigo_postal_cliente' => $data['codigo_postal_cliente'],
+            ':numero_cliente' => $data['numero_cliente'],
+            ':email_cliente' => $data['email_cliente']
+        ];
         $query = $this->db->conectar()->prepare('UPDATE cliente SET 
-            ' . $imagen_cliente . '
             nombre_cliente = :nombre_cliente,  
             apellido_paterno_cliente = :apellido_paterno_cliente,
             apellido_materno_cliente = :apellido_materno_cliente,
@@ -232,6 +209,22 @@ class ClienteDAO extends Model implements CRUD
 
         $objCliente = array_values($objCliente);
         return $objCliente;
+    }
+
+    public function updateImage($data)
+    {
+        $insertData = array(
+            ':id_cliente' => $data['id_cliente'],
+            ':imagen_cliente' => $data['imageInput'],
+        );
+
+        $queryUpdateUser = "UPDATE cliente SET 
+        imagen_cliente = :imagen_cliente
+        WHERE id_cliente = :id_cliente";
+
+        if ($this->db->ejecutarAccion($queryUpdateUser, $insertData)) {
+            echo "ok";
+        }
     }
 
 }

--- a/model/gimnasioDAO.php
+++ b/model/gimnasioDAO.php
@@ -8,44 +8,28 @@ class GimnasioDAO extends Model implements CRUD
 
     public function insert($data)
     {
-        $query = $this->db->conectar()->prepare('INSERT INTO gimnasio values (NULL, 
-            :nombre_gimnasio,
-            :telefono,  
-            :imagen)');
-        $query->execute([
+        $insertData = array(
             ':nombre_gimnasio' => $data['nombre_gimnasio'],
             ':telefono' => $data['telefono'],
-            ':imagen' => $data['imagen'],
-        ]);
-        echo 'ok';
+            ':imagen' => $data['imagen']
+        );
+        $query = "INSERT INTO gimnasio values (NULL, 
+            :nombre_gimnasio,
+            :telefono,  
+            :imagen)";
+        if ($this->db->ejecutarAccion($query, $insertData)) {
+            return $this->db->getLastInsertId();
+        }
     }
 
     public function update($data)
     {
-        $imagen = '';
-
-        $arrayActualizar = [];
-
-        if (isset($data['imagen'])) {
-
-            $imagen = 'imagen = :imagen,';
-
-            $arrayActualizar = [
-                ':id_gimnasio' => $data['id_gimnasio'],
-                ':nombre_gimnasio' => $data['nombre_gimnasio'],
-                ':telefono' => $data['telefono'],
-                ':imagen' => $data['imagen']
-            ];
-        } else {
-            $arrayActualizar = [
-                ':id_gimnasio' => $data['id_gimnasio'],
-                ':nombre_gimnasio' => $data['nombre_gimnasio'],
-                ':telefono' => $data['telefono'],
-                ':imagen' => $data['imagen']
-            ];
-        }
-        $query = $this->db->conectar()->prepare('UPDATE gimnasio SET 
-            ' . $imagen . '
+        $arrayActualizar = [
+            ':id_gimnasio' => $data['id_gimnasio'],
+            ':nombre_gimnasio' => $data['nombre_gimnasio'],
+            ':telefono' => $data['telefono']
+        ];
+        $query = $this->db->conectar()->prepare('UPDATE gimnasio SET
             nombre_gimnasio = :nombre_gimnasio,  
             telefono = :telefono
             WHERE id_gimnasio = :id_gimnasio');
@@ -75,6 +59,22 @@ class GimnasioDAO extends Model implements CRUD
             array_push($objGimnasio, $gimnasio);
         }
         return $objGimnasio;
+    }
+
+    public function updateImage($data)
+    {
+        $insertData = array(
+            ':id_gimnasio' => $data['id_gimnasio'],
+            ':imageInput' => $data['imageInput'],
+        );
+
+        $queryUpdateUser = "UPDATE gimnasio SET 
+        imagen = :imageInput
+        WHERE id_gimnasio = :id_gimnasio";
+
+        if ($this->db->ejecutarAccion($queryUpdateUser, $insertData)) {
+            echo "ok";
+        }
     }
 }
 ?>

--- a/model/usuarioDAO.php
+++ b/model/usuarioDAO.php
@@ -11,21 +11,7 @@ class UsuarioDAO extends Model implements CRUD
 
     public function insert($data)
     {
-        $query = $this->db->conectar()->prepare('INSERT INTO usuario values (NULL, 
-                :nombreUsuario,
-                :apellidoPaternoUsuario,
-                :apellidoMaternoUsuario,
-                :emailUsuario,
-                :passwordUsuario,
-                :imagen,
-                :calleUsuario,
-                :estadoUsuario,
-                :municipioUsuario,
-                :coloniaUsuario,
-                :codigoPostalUsuario,
-                :id_rol,
-                :is_active)');
-        $query->execute([
+        $insertData = array(
             ':nombreUsuario' => $data['nombreUsuario'],
             ':apellidoPaternoUsuario' => $data['apellidoPaternoUsuario'],
             ':apellidoMaternoUsuario' => $data['apellidoMaternoUsuario'],
@@ -39,8 +25,25 @@ class UsuarioDAO extends Model implements CRUD
             ':codigoPostalUsuario' => $data['codigoPostalUsuario'],
             ':id_rol' => $data['rolUsuario'],
             ':is_active' => self::CUSTOMER_INACTIVE
-        ]);
-        echo 'ok';
+        );
+        $query ="INSERT INTO usuario values (NULL, 
+                :nombreUsuario,
+                :apellidoPaternoUsuario,
+                :apellidoMaternoUsuario,
+                :emailUsuario,
+                :passwordUsuario,
+                :imagen,
+                :calleUsuario,
+                :estadoUsuario,
+                :municipioUsuario,
+                :coloniaUsuario,
+                :codigoPostalUsuario,
+                :id_rol,
+                :is_active)";
+        
+        if ($this->db->ejecutarAccion($query, $insertData)) {
+            return $this->db->getLastInsertId();
+        }
     }
 
     public function insertGymAndPlanSistema($data)
@@ -59,44 +62,21 @@ class UsuarioDAO extends Model implements CRUD
 
     public function update($data)
     {
-        $imagen = '';
-        $arrayActualizar = [];
-        if (isset($data['imagen'])) {
-            $imagen = 'imagen = :imagen,';
-            $arrayActualizar = [
-                ':id_usuario' => $data['id_usuario'],
-                ':nombreUsuario' => $data['nombreUsuario'],
-                ':apellidoPaternoUsuario' => $data['apellidoPaternoUsuario'],
-                ':apellidoMaternoUsuario' => $data['apellidoMaternoUsuario'],
-                ':emailUsuario' => $data['emailUsuario'],
-                ':passwordUsuario' => $data['passwordUsuario'],
-                ':imagen' => $data['imagen'],
-                ':calleUsuario' => $data['calleUsuario'],
-                ':estadoUsuario' => $data['estadoUsuario'],
-                ':municipioUsuario' => $data['municipioUsuario'],
-                ':coloniaUsuario' => $data['coloniaUsuario'],
-                ':codigoPostalUsuario' => $data['codigoPostalUsuario'],
-                ':id_rol' => $data['id_rol']
-            ];
-        } else {
-            $arrayActualizar = [
-                ':id_usuario' => $data['id_usuario'],
-                ':nombreUsuario' => $data['nombreUsuario'],
-                ':apellidoPaternoUsuario' => $data['apellidoPaternoUsuario'],
-                ':apellidoMaternoUsuario' => $data['apellidoMaternoUsuario'],
-                ':emailUsuario' => $data['emailUsuario'],
-                ':passwordUsuario' => $data['passwordUsuario'],
-                ':imagen' => $data['imagen'],
-                ':calleUsuario' => $data['calleUsuario'],
-                ':estadoUsuario' => $data['estadoUsuario'],
-                ':municipioUsuario' => $data['municipioUsuario'],
-                ':coloniaUsuario' => $data['coloniaUsuario'],
-                ':codigoPostalUsuario' => $data['codigoPostalUsuario'],
-                ':id_rol' => $data['id_rol']
-            ];
-        }
+        $arrayActualizar = [
+            ':id_usuario' => $data['id_usuario'],
+            ':nombreUsuario' => $data['nombreUsuario'],
+            ':apellidoPaternoUsuario' => $data['apellidoPaternoUsuario'],
+            ':apellidoMaternoUsuario' => $data['apellidoMaternoUsuario'],
+            ':emailUsuario' => $data['emailUsuario'],
+            ':passwordUsuario' => $data['passwordUsuario'],
+            ':calleUsuario' => $data['calleUsuario'],
+            ':estadoUsuario' => $data['estadoUsuario'],
+            ':municipioUsuario' => $data['municipioUsuario'],
+            ':coloniaUsuario' => $data['coloniaUsuario'],
+            ':codigoPostalUsuario' => $data['codigoPostalUsuario'],
+            ':id_rol' => $data['id_rol']
+        ];
         $query = $this->db->conectar()->prepare('UPDATE usuario SET 
-            ' . $imagen . '
             nombreUsuario = :nombreUsuario,  
             apellidoPaternoUsuario = :apellidoPaternoUsuario,
             apellidoMaternoUsuario = :apellidoMaternoUsuario,
@@ -273,6 +253,22 @@ class UsuarioDAO extends Model implements CRUD
             $objUsuario=null;
         }
         return $objUsuario;
+    }
+
+    public function updateImage($data)
+    {
+        $insertData = array(
+            ':id_user' => $data['id_user'],
+            ':imagen' => $data['imageInput'],
+        );
+
+        $queryUpdateUser = "UPDATE usuario SET 
+        imagen = :imagen
+        WHERE id_usuario = :id_user";
+
+        if ($this->db->ejecutarAccion($queryUpdateUser, $insertData)) {
+            echo "ok";
+        }
     }
 }
 ?>

--- a/model/visitaClienteDAO.php
+++ b/model/visitaClienteDAO.php
@@ -92,7 +92,7 @@ class VisitaClienteDAO extends Model implements CRUD
             $visita->date = $value['fecha'];
             $visita->hour_entry = $value['hora_entrada'];
             $visita->hour_exit = $value['hora_salida'];
-            $visita->image_client = $value['nombre_cliente'] . '_' . $value['apellido_paterno_cliente'] . '/' . $value['imagen_cliente'];
+            $visita->image_client = $value['id_cliente'] . '/' . $value['imagen_cliente'];
             $objVisita['data'][] = $visita;
             array_push($objVisita, $visita);
         }

--- a/view/cliente/cliente.php
+++ b/view/cliente/cliente.php
@@ -506,8 +506,8 @@ $menu->header('cliente');
 <div class="modal fade" id="modalUpdateImage" tabindex="-1" role="dialog" aria-labelledby="modalUpdateImage" aria-hidden="true">
     <div class="modal-dialog modal-dialog-centered" role="document">
         <div class="modal-content">
-            <div class="card-primary">
-                <div class="card-header bg-primary">
+            <div class="card-info">
+                <div class="card-header bg-info">
                     <div class="d-sm-flex align-items-center justify-content-between ">
                         <h4 class="card-title">Actualizar Imagen</h4>
                         <button type="button" class="close  d-sm-inline-block text-white" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
@@ -533,7 +533,7 @@ $menu->header('cliente');
                             </div>
                         </div>
                         <div class="text-center mt-3">
-                            <button type="submit" class="btn btn-primary">Registrar</button>
+                            <button type="submit" class="btn btn-info">Registrar</button>
                         </div>
                     </div>
                 </form>

--- a/view/cliente/cliente.php
+++ b/view/cliente/cliente.php
@@ -224,18 +224,6 @@ $menu->header('cliente');
                                             </div>
                                         </div>
                                     </div>
-                                    <div class="col-lg-12">
-                                        <span><label>Imagen del usuario (*)</label></span>
-                                        <div class="form-group input-group">
-                                            <div class="custom-file">
-                                                <input type="file" accept="image/*" class="custom-file-input"
-                                                    name="imagenClienteActualizar" id="imagenClienteActualizar"
-                                                    lang="es">
-                                                <label class="custom-file-label" for="imagen">Seleccione
-                                                    Fotografía</label>
-                                            </div>
-                                        </div>
-                                    </div>
                                     <div class="col-lg-3">
                                         <div class="form-group">
                                             <label>Nombre del Cliente (*)</label>
@@ -513,6 +501,46 @@ $menu->header('cliente');
         </div>
     </div>
 </div>
+
+<!--------------------------------------------------------- Modal Update Image ----------------------------------------------->
+<div class="modal fade" id="modalUpdateImage" tabindex="-1" role="dialog" aria-labelledby="modalUpdateImage" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered" role="document">
+        <div class="modal-content">
+            <div class="card-primary">
+                <div class="card-header bg-primary">
+                    <div class="d-sm-flex align-items-center justify-content-between ">
+                        <h4 class="card-title">Actualizar Imagen</h4>
+                        <button type="button" class="close  d-sm-inline-block text-white" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                    </div>
+                </div>
+                <form role="form" id="formUpdateImage" enctype="multipart/form-data" name="formUpdateImage" method="post">
+                    <div class="card-body">
+                        <div class="row">
+                            <div class="rounded-circle mx-auto d-inline-block overflow-hidden photo-container" style="width: 150px; height: 150px;">
+                                <img src="" alt="cliente" id="imgPreview" class="img-fluid">
+                            </div>
+                            <div class="col-lg-12">
+                                <input type="text" hidden class="form-control" id="idClientUpdateImage" name="idClientUpdateImage" placeholder="Id" />
+                            </div>
+                            <div class="col-lg-12">
+                                <div class="form-group input-group">
+                                    <div class="custom-file">
+                                        <input type="file" accept="image/*" class="custom-file-input" onchange="previewImage(event, '#imgPreview')" name="imageInput" id="imageInput" lang="es">
+                                        <label class="custom-file-label" for="imagen">Seleccione
+                                            Fotografía</label>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="text-center mt-3">
+                            <button type="submit" class="btn btn-primary">Registrar</button>
+                        </div>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
 <?php
 $menu->footer();
 ?>
@@ -525,6 +553,7 @@ $menu->footer();
         eliminarRegistro();
         rutaImagen();
         llenarplanGym();
+        sendFormUpdateImage();
     });
     const llenarplanGym = () => {
     var id_gimnasio = "<?php echo $_SESSION['id_gimnasio']; ?>"
@@ -598,7 +627,8 @@ $menu->footer();
                         <button class='consulta btn btn-primary' data-toggle='modal' data-target='#modalDetalleCliente' title="Ver Detalles"><i class="fa fa-eye"></i></button>
                         <button class='editar btn btn-warning' data-toggle='modal' data-target='#modalActualizarCliente' title="Editar Datos"><i class="fa fa-edit"></i></button>
                         <button class='eliminar btn btn-danger' data-toggle='modal' data-target='#modalEliminarCliente' title="Eliminar Registro"><i class="fa fa-trash-o"></i></button>
-                        <button class='generar-credencial btn btn-secondary' data-id-cliente="${element.id_cliente}" title="Generar Credencial"><i class="fa fa-credit-card"></i></button>`}]
+                        <button class='generar-credencial btn btn-secondary' data-id-cliente="${element.id_cliente}" title="Generar Credencial"><i class="fa fa-credit-card"></i></button>
+                        <button class='eliminar btn btn-info' data-toggle='modal' data-target='#modalUpdateImage' title="Actualizar Imagen"><i class="fa fa-picture-o"></i></button>`}]
                 })
                 return customData;
             }
@@ -609,8 +639,7 @@ $menu->footer();
             {
                 defaultContent: "",
                 'render': function (data, type, JsonResultRow, meta) {
-                    var fullnameImagen = JsonResultRow.nombre_cliente + '_' + JsonResultRow
-                        .apellido_paterno_cliente + '/' + JsonResultRow.imagen_cliente;
+                    var fullnameImagen = JsonResultRow.id_cliente + '/' + JsonResultRow.imagen_cliente;
                     var urlImg = '<?php echo constant('URL'); ?>public/cliente/' + fullnameImagen;
                     if (JsonResultRow.imagen_cliente == null || JsonResultRow.imagen_cliente ==
                         '') {
@@ -699,9 +728,21 @@ $menu->footer();
     });
 });
 
+    function previewImage(event, querySelector) {
+        const input = event.target;
+        $imgPreview = document.querySelector(querySelector);
+        if (!input.files.length) return
+        file = input.files[0];
+        objectURL = URL.createObjectURL(file);
+        $imgPreview.src = objectURL;
+    }
+
     var obtenerdatosDT = function (table) {
         $('#dataTableCliente tbody').on('click', 'tr', function () {
             var data = table.row(this).data();
+            var routeImageClient = $("#imgPreview").attr("src", '<?php echo constant('URL'); ?>public/cliente/' + data.id_cliente + '/' + data.imagen_cliente);
+            var idClientUpdateImage = $("#idClientUpdateImage").val(data.id_cliente);
+
             var idEliminar = $('#idEliminarcliente').val(data.id_cliente);
 
             var id_clienteConsultar = $("#id_clienteConsultar").val(data.id_cliente);
@@ -977,9 +1018,6 @@ $menu->footer();
                 },
                 emailClienteActualizar: {
                     required: true
-                },
-                imagenClienteActualizar: {
-                    required: true
                 }
             },
             messages: {
@@ -1009,9 +1047,76 @@ $menu->footer();
                 },
                 emailClienteActualizar: {
                     required: "Ingresa el email del cliente"
+                }
+            },
+            errorElement: 'span',
+            errorPlacement: function (error, element) {
+                error.addClass('invalid-feedback');
+                element.closest('.form-group').append(error);
+            },
+            highlight: function (element, errorClass, validClass) {
+                $(element).addClass('is-invalid');
+            },
+            unhighlight: function (element, errorClass, validClass) {
+                $(element).removeClass('is-invalid');
+            }
+        });
+    }
+
+    var imageUpdate = null;
+    $('#formUpdateImage').on('submit', function(e) {
+        imageUpdate = new FormData(this);
+    });
+    var sendFormUpdateImage = function() {
+        $.validator.setDefaults({
+            submitHandler: function(e) {
+                $.ajax({
+                    type: "POST",
+                    url: "<?php echo constant('URL'); ?>cliente/UpdateImage",
+                    data: imageUpdate,
+                    contentType: false,
+                    cache: false,
+                    processData: false,
+                    beforeSend: function() {
+                        $('.submit').attr("disabled", "disabled");
+                        $('#formUpdateImage').css("opacity", ".5");
+                    },
+                    success: function(data) {
+                        var title = "¡Éxito!";
+                        var message = "La imagen ha sido actualizada de manera correcta";
+                        var icon = "success";
+                        if (data.trim() !== 'ok') {
+                            var title = "¡Error!";
+                            var message = "Ha ocurrido un error al actualizar la imagen." + data;
+                            var icon = "error";
+                        }
+                        
+                        Swal.fire(
+                                title,
+                                message,
+                                icon
+                        ).then(function() {
+                            window.location = "<?php echo constant('URL'); ?>cliente";
+                        });
+                    },
+                });
+            }
+        });
+        $('#formUpdateImage').validate({
+            rules: {
+                idClientUpdateImage: {
+                    required: true
                 },
-                imagenClienteActualizar: {
-                    required: "Ingresa la imagen del cliente"
+                imageInput: {
+                    required: true
+                }
+            },
+            messages: {
+                idClientUpdateImage: {
+                    required: "Seleccione el cliente"
+                },
+                imageInput: {
+                    required: "Ingrese la fecha"
                 }
             },
             errorElement: 'span',

--- a/view/cliente/cliente.php
+++ b/view/cliente/cliente.php
@@ -533,7 +533,7 @@ $menu->header('cliente');
                             </div>
                         </div>
                         <div class="text-center mt-3">
-                            <button type="submit" class="btn btn-info">Registrar</button>
+                            <button type="submit" class="btn btn-info">Actualizar</button>
                         </div>
                     </div>
                 </form>

--- a/view/gimnasio/index.php
+++ b/view/gimnasio/index.php
@@ -144,18 +144,6 @@ $menu->header('gimnasio');
                             </div>
                             <div class="card-body">
                                 <div class="row">
-                                    <div class="col-lg-12">
-                                        <span><label>Imagen (*)</label></span>
-                                        <div class="form-group input-group">
-                                            <div class="custom-file">
-                                                <input type="file" accept="image/*" class="custom-file-input"
-                                                    name="imagenGimnasioActualizar" id="imagenGimnasioActualizar"
-                                                    lang="es">
-                                                <label class="custom-file-label" for="imagen">Seleccione
-                                                    Fotografía</label>
-                                            </div>
-                                        </div>
-                                    </div>
                                     <div style="display: none;" class="row">
                                         <div class="col-lg-6">
                                             <div class="form-group">
@@ -290,6 +278,46 @@ $menu->header('gimnasio');
     </div>
 </div>
 
+<!--------------------------------------------------------- Modal Update Image ----------------------------------------------->
+<div class="modal fade" id="modalUpdateImage" tabindex="-1" role="dialog" aria-labelledby="modalUpdateImage" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered" role="document">
+        <div class="modal-content">
+            <div class="card-primary">
+                <div class="card-header bg-primary">
+                    <div class="d-sm-flex align-items-center justify-content-between ">
+                        <h4 class="card-title">Actualizar Imagen</h4>
+                        <button type="button" class="close  d-sm-inline-block text-white" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                    </div>
+                </div>
+                <form role="form" id="formUpdateImage" enctype="multipart/form-data" name="formUpdateImage" method="post">
+                    <div class="card-body">
+                        <div class="row">
+                            <div class="rounded-circle mx-auto d-inline-block overflow-hidden photo-container" style="width: 150px; height: 150px;">
+                                <img src="" alt="gimnasio" id="imgPreview" class="img-fluid">
+                            </div>
+                            <div class="col-lg-12">
+                                <input type="text" hidden class="form-control" id="idGymUpdateImage" name="idGymUpdateImage" placeholder="Id" />
+                            </div>
+                            <div class="col-lg-12">
+                                <div class="form-group input-group">
+                                    <div class="custom-file">
+                                        <input type="file" accept="image/*" class="custom-file-input" onchange="previewImage(event, '#imgPreview')" name="imageInput" id="imageInput" lang="es">
+                                        <label class="custom-file-label" for="imagen">Seleccione
+                                            Fotografía</label>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="text-center mt-3">
+                            <button type="submit" class="btn btn-primary">Registrar</button>
+                        </div>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+
 <?php
 $menu->footer();
 ?>
@@ -301,6 +329,7 @@ $menu->footer();
         enviarFormularioActualizar();
         eliminarRegistro();
         rutaImagen();
+        sendFormUpdateImage();
     });
 
     $(".custom-file-input").on("change", function () {
@@ -346,8 +375,7 @@ $menu->footer();
             {
                 defaultContent: "",
                 'render': function (data, type, JsonResultRow, meta) {
-                    var fullnameImagen = JsonResultRow.nombre_gimnasio + '_' + JsonResultRow
-                        .telefono + '/' + JsonResultRow.imagen;
+                    var fullnameImagen = JsonResultRow.id_gimnasio + '/' + JsonResultRow.imagen;
                     var urlImg = '<?php echo constant('URL'); ?>public/gimnasio/' + fullnameImagen;
                     if (JsonResultRow.imagen == null || JsonResultRow.imagen == '') {
                         var urlImg = '<?php echo constant('URL'); ?>public/img/forcefit.png';
@@ -375,7 +403,8 @@ $menu->footer();
                 data: null,
                 "defaultContent": `<button class='consulta btn btn-primary' data-toggle='modal' data-target='#modalDetalleGimnasio' title="Ver Detalles"><i class="fa fa-eye"></i></button>
                         <button class='editar btn btn-warning' data-toggle='modal' data-target='#modalActualizarGimnasio' title="Editar Datos"><i class="fa fa-edit"></i></button>
-                        <button class='eliminar btn btn-danger' data-toggle='modal' data-target='#modalEliminarGimnasio' title="Eliminar Registro"><i class="fa fa-trash-o"></i></button>`
+                        <button class='eliminar btn btn-danger' data-toggle='modal' data-target='#modalEliminarGimnasio' title="Eliminar Registro"><i class="fa fa-trash-o"></i></button>
+                        <button class='eliminar btn btn-info' data-toggle='modal' data-target='#modalUpdateImage' title="Actualizar Imagen"><i class="fa fa-picture-o"></i></button>`
             }
             ],
             responsive: true,
@@ -388,9 +417,21 @@ $menu->footer();
         obtenerdatosDT(tableGimnasio);
     }
 
+    function previewImage(event, querySelector) {
+        const input = event.target;
+        $imgPreview = document.querySelector(querySelector);
+        if (!input.files.length) return
+        file = input.files[0];
+        objectURL = URL.createObjectURL(file);
+        $imgPreview.src = objectURL;
+    }
+
     var obtenerdatosDT = function (table) {
         $('#dataTableGimnasio tbody').on('click', 'tr', function () {
             var data = table.row(this).data();
+            var routeImageGym = $("#imgPreview").attr("src", '<?php echo constant('URL'); ?>public/gimnasio/' + data.id_gimnasio + '/' + data.imagen);
+            var idGymUpdateImage = $("#idGymUpdateImage").val(data.id_gimnasio);
+
             var idEliminar = $('#idEliminarGimnasio').val(data.id_gimnasio);
 
             var idGimnasioActualizar = $("#idGimnasioActualizar").val(data.id_gimnasio);
@@ -573,10 +614,7 @@ $menu->footer();
                 },
                 telefonoActualizar: {
                     required: true
-                },
-                imagenGimnasioActualizar: {
-                    required: true
-                },
+                }
             },
             messages: {
                 idGimnasioActualizar: {
@@ -588,10 +626,77 @@ $menu->footer();
                 },
                 telefonoActualizar: {
                     required: "Ingresa un número de teléfono"
+                }
+            },
+            errorElement: 'span',
+            errorPlacement: function (error, element) {
+                error.addClass('invalid-feedback');
+                element.closest('.form-group').append(error);
+            },
+            highlight: function (element, errorClass, validClass) {
+                $(element).addClass('is-invalid');
+            },
+            unhighlight: function (element, errorClass, validClass) {
+                $(element).removeClass('is-invalid');
+            }
+        });
+    }
+
+    var imageUpdate = null;
+    $('#formUpdateImage').on('submit', function(e) {
+        imageUpdate = new FormData(this);
+    });
+    var sendFormUpdateImage = function() {
+        $.validator.setDefaults({
+            submitHandler: function(e) {
+                $.ajax({
+                    type: "POST",
+                    url: "<?php echo constant('URL'); ?>gimnasio/UpdateImage",
+                    data: imageUpdate,
+                    contentType: false,
+                    cache: false,
+                    processData: false,
+                    beforeSend: function() {
+                        $('.submit').attr("disabled", "disabled");
+                        $('#formUpdateImage').css("opacity", ".5");
+                    },
+                    success: function(data) {
+                        var title = "¡Éxito!";
+                        var message = "La imagen ha sido actualizada de manera correcta";
+                        var icon = "success";
+                        if (data.trim() !== 'ok') {
+                            var title = "¡Error!";
+                            var message = "Ha ocurrido un error al actualizar la imagen." + data;
+                            var icon = "error";
+                        }
+                        
+                        Swal.fire(
+                                title,
+                                message,
+                                icon
+                        ).then(function() {
+                            window.location = "<?php echo constant('URL'); ?>gimnasio";
+                        });
+                    },
+                });
+            }
+        });
+        $('#formUpdateImage').validate({
+            rules: {
+                idGymUpdateImage: {
+                    required: true
                 },
-                imagenGimnasioActualizar: {
-                    required: "Ingresa una imagen"
+                imageInput: {
+                    required: true
+                }
+            },
+            messages: {
+                idGymUpdateImage: {
+                    required: "Seleccione el gimnasio"
                 },
+                imageInput: {
+                    required: "Ingrese la fecha"
+                }
             },
             errorElement: 'span',
             errorPlacement: function (error, element) {

--- a/view/gimnasio/index.php
+++ b/view/gimnasio/index.php
@@ -282,8 +282,8 @@ $menu->header('gimnasio');
 <div class="modal fade" id="modalUpdateImage" tabindex="-1" role="dialog" aria-labelledby="modalUpdateImage" aria-hidden="true">
     <div class="modal-dialog modal-dialog-centered" role="document">
         <div class="modal-content">
-            <div class="card-primary">
-                <div class="card-header bg-primary">
+            <div class="card-info">
+                <div class="card-header bg-info">
                     <div class="d-sm-flex align-items-center justify-content-between ">
                         <h4 class="card-title">Actualizar Imagen</h4>
                         <button type="button" class="close  d-sm-inline-block text-white" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
@@ -309,7 +309,7 @@ $menu->header('gimnasio');
                             </div>
                         </div>
                         <div class="text-center mt-3">
-                            <button type="submit" class="btn btn-primary">Registrar</button>
+                            <button type="submit" class="btn btn-info">Registrar</button>
                         </div>
                     </div>
                 </form>

--- a/view/gimnasio/index.php
+++ b/view/gimnasio/index.php
@@ -309,7 +309,7 @@ $menu->header('gimnasio');
                             </div>
                         </div>
                         <div class="text-center mt-3">
-                            <button type="submit" class="btn btn-info">Registrar</button>
+                            <button type="submit" class="btn btn-info">Actualizar</button>
                         </div>
                     </div>
                 </form>

--- a/view/menu.php
+++ b/view/menu.php
@@ -6,14 +6,14 @@ class Menu
         $nombre = $_SESSION['nombreUsuario'];
         $foto = $_SESSION['imagen'];
         $appaterno = $_SESSION['apellidoPaternoUsuario'];
-        $id_usuario = $_SESSION['id_usuario'];
+        $idUsuario = $_SESSION['id_usuario'];
         $fotoruta = constant('URL') . 'public/usuario/' . $nombre . '_' . $appaterno  . '/' . $foto;
         if ($foto != null){
-            $fotoruta ='public/usuario/' . $id_usuario . '_' .$nombre . '_' . $appaterno  . '/' . $foto;
+            $fotoruta ='public/usuario/' . $idUsuario . '/' . $foto;
             if(!file_exists($fotoruta)){
               $fotoruta= constant('URL') . 'public/img/avatar.png';
             }else{
-                $fotoruta = constant('URL') . 'public/usuario/' . $id_usuario . '_' . $nombre . '_' . $appaterno  . '/' . $foto;
+                $fotoruta = constant('URL') . 'public/usuario/' . $idUsuario . '/' . $foto;
             }
           }else{
             $fotoruta= constant('URL') . 'public/img/avatar.png';

--- a/view/perfil/index.php
+++ b/view/perfil/index.php
@@ -213,7 +213,7 @@ $menu->footer();
                 var postalcodeUser = $("#postalcodeUser").val(data[0].codigoPostalUsuario);
                 var nameRol = $("#nameRol").text(data[0].nombreRol);
                 var descriptionRol = $("#descriptionRol").text(data[0].descripcion);
-                var imageUser = $("#imageUser").attr("src", '<?php echo constant('URL'); ?>public/usuario/' + data[0].id_usuario + '_' + data[0].nombreUsuario + '_' + data[0].apellidoPaternoUsuario + '/' + data[0].imagen);
+                var imageUser = $("#imageUser").attr("src", '<?php echo constant('URL'); ?>public/usuario/' + data[0].id_usuario +  '/' + data[0].imagen);
                 var rolUser = $("#rolUser").val(data[0].nombreRol);
                 var fullNameUser = $("#fullNameUser").text(data[0].nombreUsuario + ' ' + data[0].apellidoPaternoUsuario + ' ' + data[0].apellidoMaternoUsuario);
             },
@@ -229,7 +229,7 @@ $menu->footer();
     });
     $('#formUpdatePerfil').on('submit', function(e) {
         datosActualizar = new FormData(this);
-        datosActualizar.append('id_usuario', "<?php echo $_SESSION['id_usuario']; ?>");
+        datosActualizar.append('idUsuario', "<?php echo $_SESSION['id_usuario']; ?>");
         datosActualizar.append('oldNameUser', "<?php echo $_SESSION['nombreUsuario']; ?>");
         datosActualizar.append('oldLastNameUser', "<?php echo $_SESSION['apellidoPaternoUsuario']; ?>");
         datosActualizar.append('imagen', "<?php echo $_SESSION['imagen']; ?>");

--- a/view/usuario/index.php
+++ b/view/usuario/index.php
@@ -639,7 +639,7 @@ $menu->header('usuario');
                             </div>
                         </div>
                         <div class="text-center mt-3">
-                            <button type="submit" class="btn btn-info">Registrar</button>
+                            <button type="submit" class="btn btn-info">Actualizar</button>
                         </div>
                     </div>
                 </form>

--- a/view/usuario/index.php
+++ b/view/usuario/index.php
@@ -611,8 +611,8 @@ $menu->header('usuario');
 <div class="modal fade" id="modalUpdateImage" tabindex="-1" role="dialog" aria-labelledby="modalUpdateImage" aria-hidden="true">
     <div class="modal-dialog modal-dialog-centered" role="document">
         <div class="modal-content">
-            <div class="card-primary">
-                <div class="card-header bg-primary">
+            <div class="card-info">
+                <div class="card-header bg-info">
                     <div class="d-sm-flex align-items-center justify-content-between ">
                         <h4 class="card-title">Actualizar Imagen</h4>
                         <button type="button" class="close  d-sm-inline-block text-white" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
@@ -639,7 +639,7 @@ $menu->header('usuario');
                             </div>
                         </div>
                         <div class="text-center mt-3">
-                            <button type="submit" class="btn btn-primary">Registrar</button>
+                            <button type="submit" class="btn btn-info">Registrar</button>
                         </div>
                     </div>
                 </form>

--- a/view/usuario/index.php
+++ b/view/usuario/index.php
@@ -232,18 +232,6 @@ $menu->header('usuario');
                                             </div>
                                         </div>
                                     </div>
-                                    <div class="col-lg-12">
-                                        <span><label>Imagen del usuario (*)</label></span>
-                                        <div class="form-group input-group">
-                                            <div class="custom-file">
-                                                <input type="file" accept="image/*" class="custom-file-input"
-                                                    name="imagenUsuarioActualizar" id="imagenUsuarioActualizar"
-                                                    lang="es">
-                                                <label class="custom-file-label" for="imagen">Seleccione
-                                                    Fotografía</label>
-                                            </div>
-                                        </div>
-                                    </div>
                                     <div class="col-lg-3">
                                         <div class="form-group">
                                             <label>Nombre del Usuario (*)</label>
@@ -618,6 +606,47 @@ $menu->header('usuario');
         </div>
     </div>
 </div>
+
+<!--------------------------------------------------------- Modal Update Image ----------------------------------------------->
+<div class="modal fade" id="modalUpdateImage" tabindex="-1" role="dialog" aria-labelledby="modalUpdateImage" aria-hidden="true">
+    <div class="modal-dialog modal-dialog-centered" role="document">
+        <div class="modal-content">
+            <div class="card-primary">
+                <div class="card-header bg-primary">
+                    <div class="d-sm-flex align-items-center justify-content-between ">
+                        <h4 class="card-title">Actualizar Imagen</h4>
+                        <button type="button" class="close  d-sm-inline-block text-white" data-dismiss="modal" aria-label="Close"><span aria-hidden="true">&times;</span></button>
+                    </div>
+                </div>
+                <form role="form" id="formUpdateImage" enctype="multipart/form-data" name="formUpdateImage" method="post">
+                    <div class="card-body">
+                        <div class="row">
+                            <div class="rounded-circle mx-auto d-inline-block overflow-hidden photo-container" style="width: 150px; height: 150px;">
+                                <img src="" alt="cliente" id="imgPreview" class="img-fluid">
+                            </div>
+                            <div class="col-lg-12">
+                                <input type="text" hidden class="form-control" id="idUserUpdateImage" name="idUserUpdateImage" placeholder="Id" />
+                            </div>
+                            <div class="col-lg-12">
+                                <span><label>Imagen del usuario (*)</label></span>
+                                <div class="form-group input-group">
+                                    <div class="custom-file">
+                                        <input type="file" accept="image/*" class="custom-file-input" onchange="previewImage(event, '#imgPreview')" name="imageInput" id="imageInput" lang="es">
+                                        <label class="custom-file-label" for="imagen">Seleccione
+                                            Fotografía</label>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                        <div class="text-center mt-3">
+                            <button type="submit" class="btn btn-primary">Registrar</button>
+                        </div>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
 <?php
 $menu->footer();
 ?>
@@ -633,6 +662,7 @@ $menu->footer();
         llenarRol();
         llenarGimasio();
         llenarPlanSistema();
+        sendFormUpdateImage();
     });
 
     const llenarRol = () => {
@@ -731,8 +761,7 @@ const llenarPlanSistema = () => {
             {
                 defaultContent: "",
                 'render': function (data, type, JsonResultRow, meta) {
-                    var fullnameImagen = JsonResultRow.nombreUsuario + '_' + JsonResultRow
-                        .apellidoPaternoUsuario + '/' + JsonResultRow.imagen;
+                    var fullnameImagen = JsonResultRow.id_usuario + '/' + JsonResultRow.imagen;
                     var urlImg = '<?php echo constant('URL'); ?>public/usuario/' + fullnameImagen;
                     if (JsonResultRow.imagen == null || JsonResultRow.imagen ==
                         '') {
@@ -780,6 +809,7 @@ const llenarPlanSistema = () => {
                         <button class='editar btn btn-warning' data-toggle='modal' data-target='#modalActualizarUsuario' title="Editar Datos"><i class="fa fa-edit"></i></button>
                         <button class='eliminar btn btn-danger' data-toggle='modal' data-target='#modalEliminarUsuario' title="Eliminar Registro"><i class="fa fa-trash-o"></i></button>
                         <button class='asignacion btn btn-primary' data-toggle='modal' data-target='#modalAsignarGimnasioYPlanSistema' title="Asignar Gimnasio y Plan Sistema"><i class="fa fa-plus"></i> Asignar</button>
+                        <button class='eliminar btn btn-info' data-toggle='modal' data-target='#modalUpdateImage' title="Actualizar Imagen"><i class="fa fa-picture-o"></i></button>
                         `
             }
             ],
@@ -792,9 +822,22 @@ const llenarPlanSistema = () => {
         });
         obtenerdatosDT(tableUsuario);
     }
+
+    function previewImage(event, querySelector) {
+        const input = event.target;
+        $imgPreview = document.querySelector(querySelector);
+        if (!input.files.length) return
+        file = input.files[0];
+        objectURL = URL.createObjectURL(file);
+        $imgPreview.src = objectURL;
+    }
+
     var obtenerdatosDT = function (table) {
         $('#dataTableUsuario tbody').on('click', 'tr', function () {
             var data = table.row(this).data();
+            var routeImageUser = $("#imgPreview").attr("src", '<?php echo constant('URL'); ?>public/usuario/' + data.id_usuario + '/' + data.imagen);
+            var idUserUpdateImage = $("#idUserUpdateImage").val(data.id_usuario);
+
             var idEliminar = $('#idEliminarUsuario').val(data.id_usuario);
 
             var id_usuarioAsignar= $("#id_usuarioAsignar").val(data.id_usuario);
@@ -1128,9 +1171,6 @@ const llenarPlanSistema = () => {
                 contraseñaUsuarioActualizar: {
                     required: true
                 },
-                imagenUsuarioActualizar: {
-                    required: true
-                },
                 calleUsuarioActualizar: {
                     required: true
                 },
@@ -1170,9 +1210,6 @@ const llenarPlanSistema = () => {
                 contraseñaUsuarioActualizar: {
                     required: "Ingrese contraseña"
                 },
-                imagenUsuarioActualizar: {
-                    required: "Ingrese una imagen"
-                },
                 calleUsuarioActualizar: {
                     required: "Ingrese calle"
                 },
@@ -1190,6 +1227,76 @@ const llenarPlanSistema = () => {
                 },
                 rolUsuarioActualizar: {
                     required: "Ingrese rol"
+                }
+            },
+            errorElement: 'span',
+            errorPlacement: function (error, element) {
+                error.addClass('invalid-feedback');
+                element.closest('.form-group').append(error);
+            },
+            highlight: function (element, errorClass, validClass) {
+                $(element).addClass('is-invalid');
+            },
+            unhighlight: function (element, errorClass, validClass) {
+                $(element).removeClass('is-invalid');
+            }
+        });
+    }
+
+    var imageUpdate = null;
+    $('#formUpdateImage').on('submit', function(e) {
+        imageUpdate = new FormData(this);
+    });
+    var sendFormUpdateImage = function() {
+        $.validator.setDefaults({
+            submitHandler: function(e) {
+                $.ajax({
+                    type: "POST",
+                    url: "<?php echo constant('URL'); ?>usuario/UpdateImage",
+                    data: imageUpdate,
+                    contentType: false,
+                    cache: false,
+                    processData: false,
+                    beforeSend: function() {
+                        $('.submit').attr("disabled", "disabled");
+                        $('#formUpdateImage').css("opacity", ".5");
+                    },
+                    success: function(data) {
+                        var title = "¡Éxito!";
+                        var message = "La imagen ha sido actualizada de manera correcta";
+                        var icon = "success";
+                        if (data.trim() !== 'ok') {
+                            var title = "¡Error!";
+                            var message = "Ha ocurrido un error al actualizar la imagen." + data;
+                            var icon = "error";
+                        }
+                        
+                        Swal.fire(
+                                title,
+                                message,
+                                icon
+                        ).then(function() {
+                            window.location = "<?php echo constant('URL'); ?>usuario";
+                        });
+                    },
+                });
+            }
+        });
+        $('#formUpdateImage').validate({
+            rules: {
+                idClientUpdateImage: {
+                    required: true
+                },
+                imageInput: {
+                    required: true
+                }
+            },
+            messages: {
+                idClientUpdateImage: {
+                    required: "Seleccione el cliente"
+                },
+                imageInput: {
+                    required: "Ingrese la fecha"
                 }
             },
             errorElement: 'span',


### PR DESCRIPTION
Se elimino el input que almacenaba la imagen dentro de los formularios para editar un registro, implementando un nuevo botón en los data tables, para que el usuario pueda actualizar la imagen de los registros por separado, cambiando también la forma en que se nombraba el folder para guardar la imagen, en donde el nombre del folder ahora será el id del registro.
